### PR TITLE
feat: map environment secrets to robot variable

### DIFF
--- a/camunda-utils/Camunda/Camunda.py
+++ b/camunda-utils/Camunda/Camunda.py
@@ -11,6 +11,7 @@ from robot.api import logger
 from robot.libraries.BuiltIn import BuiltIn
 
 SECRET_VARIABLE = "${secrets}"
+SECRET_ENV_NAME = "CAMUNDA_SECRETS"
 
 
 class Secrets(dict):
@@ -40,7 +41,7 @@ class Camunda:
 
     def _map_secrets(self):
         """
-        Secrets are provided as environment variables with the prefix 'SECRET_' to the robot file.
+        Secrets are provided as a JSON object in the environment variable 'CAMUNDA_SECRETS'.
         For easy access, we want to provide them as a robot variable instead.
         """
 
@@ -52,16 +53,13 @@ class Camunda:
         if existing_secrets:
             return
 
-        # Get all Secrets from ENV, remove prefix
-        secrets = {
-            key[7:]: value
-            for key, value in os.environ.items()
-            if key.startswith("SECRET_")
-        }
+        # Get secrets from the environment variable
+        secrets_json = os.getenv(SECRET_ENV_NAME)
 
-        if not secrets:
+        if not secrets_json:
             return
 
+        secrets = json.loads(secrets_json)
         secrets_wrapper = Secrets(secrets)
 
         # Set Robot variable

--- a/camunda-utils/Camunda/Camunda.py
+++ b/camunda-utils/Camunda/Camunda.py
@@ -21,9 +21,7 @@ class Secrets(dict):
     """
 
     def __getattr__(self, name):
-        if name in self:
-            return self[name]
-        raise AttributeError(f"'Secrets' object has no attribute '{name}'")
+        return self[name]
 
 
 class Camunda:

--- a/camunda-utils/Camunda/test_Camunda.py
+++ b/camunda-utils/Camunda/test_Camunda.py
@@ -26,7 +26,10 @@ def test_secrets_non_existent_key():
         _ = secrets.KEY2
 
 
-@patch("os.environ", {"SECRET_KEY1": "value1", "SECRET_KEY2": "value2"})
+@patch(
+    "os.environ",
+    {"CAMUNDA_SECRETS": '{"KEY1": "value1", "KEY2": "value2"}'},
+)
 @patch("robot.libraries.BuiltIn.BuiltIn.get_variable_value", return_value=None)
 @patch("robot.libraries.BuiltIn.BuiltIn.set_global_variable")
 def test_secret_mapping(mock_set_global_variable, mock_get_variable_value):

--- a/camunda-utils/Camunda/test_Camunda.py
+++ b/camunda-utils/Camunda/test_Camunda.py
@@ -20,9 +20,7 @@ def test_secrets_non_existent_key():
     secrets_dict = {"KEY1": "value1"}
     secrets = Secrets(secrets_dict)
 
-    with pytest.raises(
-        AttributeError, match="'Secrets' object has no attribute 'KEY2'"
-    ):
+    with pytest.raises(KeyError):
         _ = secrets.KEY2
 
 

--- a/camunda-utils/Camunda/test_Camunda.py
+++ b/camunda-utils/Camunda/test_Camunda.py
@@ -1,12 +1,76 @@
 import pytest
 import requests
 from unittest.mock import patch, Mock
-from .Camunda import Camunda
+from .Camunda import Camunda, Secrets
 
 
+# Secret mapping
+
+
+# Test for Secrets class
+def test_secrets_retrieval():
+    secrets_dict = {"KEY1": "value1", "KEY2": "value2"}
+    secrets = Secrets(secrets_dict)
+
+    assert secrets.KEY1 == "value1"
+    assert secrets.KEY2 == "value2"
+
+
+def test_secrets_non_existent_key():
+    secrets_dict = {"KEY1": "value1"}
+    secrets = Secrets(secrets_dict)
+
+    with pytest.raises(
+        AttributeError, match="'Secrets' object has no attribute 'KEY2'"
+    ):
+        _ = secrets.KEY2
+
+
+@patch("os.environ", {"SECRET_KEY1": "value1", "SECRET_KEY2": "value2"})
+@patch("robot.libraries.BuiltIn.BuiltIn.get_variable_value", return_value=None)
+@patch("robot.libraries.BuiltIn.BuiltIn.set_global_variable")
+def test_secret_mapping(mock_set_global_variable, mock_get_variable_value):
+    camunda = Camunda()
+
+    mock_set_global_variable.assert_called_with(
+        "${secrets}", {"KEY1": "value1", "KEY2": "value2"}
+    )
+
+    # Assert access via attributes
+    SECRETS = mock_set_global_variable.call_args[0][1]
+
+    assert SECRETS.KEY1 == "value1"
+    assert SECRETS.KEY2 == "value2"
+
+
+@patch("os.environ", {})
+@patch("robot.libraries.BuiltIn.BuiltIn.get_variable_value", return_value=None)
+@patch("robot.libraries.BuiltIn.BuiltIn.set_global_variable")
+def test_secret_mapping_no_secrets(mock_set_global_variable, mock_get_variable_value):
+    camunda = Camunda()
+    mock_set_global_variable.assert_not_called()
+
+
+@patch("os.environ", {"SECRET_KEY1": "value1"})
+@patch(
+    "robot.libraries.BuiltIn.BuiltIn.get_variable_value",
+    return_value={"EXISTING_KEY": "existing_value"},
+)
+@patch("robot.libraries.BuiltIn.BuiltIn.set_global_variable")
+def test_secret_mapping_existing_variable(
+    mock_set_global_variable, mock_get_variable_value
+):
+    camunda = Camunda()
+    mock_set_global_variable.assert_not_called()
+
+
+### File Handling
 @pytest.fixture
 def camunda():
-    return Camunda()
+    with patch("robot.libraries.BuiltIn.BuiltIn.get_variable_value"), patch(
+        "robot.libraries.BuiltIn.BuiltIn.set_global_variable"
+    ):
+        return Camunda()
 
 
 # File Upload

--- a/camunda-utils/setup.py
+++ b/camunda-utils/setup.py
@@ -6,7 +6,7 @@ os.chdir(setup_dir)
 
 setup(
     name="camunda-utils",
-    version="0.1.0",
+    version="0.2.0",
     description="Offer keywords to interact with Camunda from the RPA worker",
     author="Camunda Services GmbH",
     author_email="info@camunda.com",


### PR DESCRIPTION
This PR maps all `SECRET_` environment variables to the Robot variable `${secrets}`.

In the script, you can then access secrets via

```
*** Settings ***
Library             Camunda

*** Tasks ***
Complete the challenge
    Log    ${secrets.KEY}
```

This is similar to the [secrets handling in connectors](https://docs.camunda.io/docs/components/connectors/use-connectors/#using-secrets), eg. `= { myHeader: "{{secrets.MY_API_KEY}}"}` 

closes https://github.com/camunda/rpa-python-libraries/issues/3