### PR TITLE
feat(camunda-rpa): patch `Open Browser` keyword

### DIFF
--- a/camunda-rpa/Camunda/Browser/Selenium/__init__.py
+++ b/camunda-rpa/Camunda/Browser/Selenium/__init__.py
@@ -1,1 +1,59 @@
-from RPA.Browser.Selenium import *
+from typing import Union, Optional
+from robot.api.deco import keyword
+from RPA.Browser.common import AUTO, auto_headless
+from RPA.Browser.Selenium import (
+    BrowserManagementKeywords as _BrowserManagementKeywords,
+    Selenium as _Selenium,
+    ArgOptions,
+    OptionsType,
+)
+from robot.api import logger
+
+
+class BrowserManagementKeywords(_BrowserManagementKeywords):
+    """Overridden keywords for browser management."""
+
+    def __init__(self, ctx):
+        super().__init__(ctx)
+
+    @keyword
+    @auto_headless
+    def open_browser(
+        self,
+        *args,
+        browser: str = "firefox",
+        headless: Union[bool, str] = AUTO,
+        sandbox: bool = False,
+        options: Optional[OptionsType] = None,
+        **kwargs,
+    ) -> str:
+        if headless:
+            # Map the headless argument to the browser argument
+            # firefox, ff => headlessfirefox
+            # googlechrome, chrome, gc => headlesschrome
+
+            if browser == "firefox" or browser == "ff":
+                browser = "headlessfirefox"
+
+            if browser == "googlechrome" or browser == "chrome" or browser == "gc":
+                browser = "headlesschrome"
+
+        # Disable sandbox by default
+        options: ArgOptions = self.ctx.normalize_options(options, browser=browser)
+        if not sandbox:
+            options.add_argument("--no-sandbox")
+
+        super().open_browser(*args, browser=browser, options=options, **kwargs)
+
+    open_browser.__doc__ = _BrowserManagementKeywords.open_browser.__doc__
+
+
+class Selenium(_Selenium):
+    def __init__(self, *args, **kwargs):
+        self.AVAILABLE_OPTIONS["headlesschrome"] = self.AVAILABLE_OPTIONS["chrome"]
+        self.AVAILABLE_OPTIONS["headlessfirefox"] = self.AVAILABLE_OPTIONS["firefox"]
+
+        super().__init__(*args, **kwargs)
+
+        self.browser_management = BrowserManagementKeywords(self)
+        self.add_library_components([self.browser_management])

--- a/camunda-rpa/setup.py
+++ b/camunda-rpa/setup.py
@@ -6,7 +6,7 @@ os.chdir(setup_dir)
 
 setup(
     name="camunda-rpa",
-    version="0.2.0",
+    version="0.3.0",
     description="Exposes RPA libraries under the Camunda namespace",
     author="Camunda Services GmbH",
     author_email="info@camunda.com",
@@ -34,5 +34,10 @@ setup(
         "Camunda.Windows",
         "Camunda.Word.Application",
     ],
-    install_requires=["rpaframework", "rpaframework-pdf", "rpaframework-windows"],
+    install_requires=[
+        "selenium==4.29.0",
+        "rpaframework",
+        "rpaframework-pdf",
+        "rpaframework-windows",
+    ],
 )

--- a/camunda-rpa/setup.py
+++ b/camunda-rpa/setup.py
@@ -35,7 +35,9 @@ setup(
         "Camunda.Word.Application",
     ],
     install_requires=[
-        "selenium==4.29.0",
+        "selenium >= 4.29.0",
+        "pillow >= 10.4.0",
+        "PyYAML >= 6.0.0",
         "rpaframework",
         "rpaframework-pdf",
         "rpaframework-windows",


### PR DESCRIPTION
This PR patches the `Open Browser` keyword.

It automatically switches to headless execution in a headless environment and disables the sandbox by default.