### PR TITLE
fix: remove extra dependencies that break installation

### DIFF
--- a/camunda-rpa/setup.py
+++ b/camunda-rpa/setup.py
@@ -35,11 +35,8 @@ setup(
         "Camunda.Word.Application",
     ],
     install_requires=[
-        "selenium >= 4.29.0",
-        "pillow >= 10.4.0",
-        "PyYAML >= 6.0.0",
-        "rpaframework",
-        "rpaframework-pdf",
-        "rpaframework-windows",
+        "rpaframework >= 30",
+        "rpaframework-pdf >= 8",
+        "rpaframework-windows >= 9",
     ],
 )

--- a/camunda-rpa/setup.py
+++ b/camunda-rpa/setup.py
@@ -6,7 +6,7 @@ os.chdir(setup_dir)
 
 setup(
     name="camunda-rpa",
-    version="0.3.0",
+    version="0.3.1",
     description="Exposes RPA libraries under the Camunda namespace",
     author="Camunda Services GmbH",
     author_email="info@camunda.com",


### PR DESCRIPTION
With https://github.com/camunda/rpa-python-libraries/pull/12 we introduced a change trying to bump the selenium version.

As it turns out, this will just cause rpaframework 0.1.0 to be installed. This was not the intention.
Let's revert this change and figure out how to update selenium in a non-destructive manner to get FireFox working