### PR TITLE
chore(utils): always create an array of file descriptors

### DIFF
--- a/camunda-rpa/setup.py
+++ b/camunda-rpa/setup.py
@@ -6,7 +6,7 @@ os.chdir(setup_dir)
 
 setup(
     name="camunda-rpa",
-    version="0.3.1",
+    version="1.0.0",
     description="Exposes RPA libraries under the Camunda namespace",
     author="Camunda Services GmbH",
     author_email="info@camunda.com",

--- a/camunda-utils/Camunda/Camunda.py
+++ b/camunda-utils/Camunda/Camunda.py
@@ -152,17 +152,17 @@ class Camunda:
         .. code-block:: robotframework
 
             # Upload a single file
-            Upload Document    path/to/file.txt
+            ${fileDescriptor}=   Upload Document    path/to/file.txt
             Set Output Variable    fileDescriptor    ${fileDescriptor}
 
             # Directly store the file descriptor in a variable
-            Upload Document    path/to/file.txt
+            Upload Document    path/to/file.txt     variableName="fileDescriptor"
 
             # Upload all files in a directory
             Upload Document    path/to/directory/*   variableName="invoices"
 
             # Upload all .pdf files in the workspace
-            Set Output Variable    fileDescriptor    variableName="invoices"
+            Upload Document    *.pdf   variableName="pdfs"
         """
         url = f"{self.base_url}/file/store/{self.workspace_id}"
         headers = {"Content-Type": "application/json"}

--- a/camunda-utils/Camunda/Camunda.py
+++ b/camunda-utils/Camunda/Camunda.py
@@ -176,10 +176,6 @@ class Camunda:
 
         fileDescriptors = list(response.json().values())
 
-        # If we only have 1 file, return the file descriptor as a string
-        if len(fileDescriptors) == 1:
-            fileDescriptors = fileDescriptors[0]
-
         if variableName:
             self.set_output_variable(variableName, fileDescriptors)
 

--- a/camunda-utils/Camunda/test_Camunda.py
+++ b/camunda-utils/Camunda/test_Camunda.py
@@ -229,7 +229,7 @@ def test_upload_documents_single_file(mock_set_output_variable, mock_post, camun
     mock_post.return_value = mock_response
 
     result = camunda.upload_documents("file1.txt")
-    assert result == "descriptor1"
+    assert result == ["descriptor1"]
     mock_set_output_variable.assert_not_called()
 
 
@@ -257,8 +257,8 @@ def test_upload_documents_with_variable_name(
     mock_post.return_value = mock_response
 
     result = camunda.upload_documents("file1.txt", variableName="fileDescriptor")
-    assert result == "descriptor1"
-    mock_set_output_variable.assert_called_once_with("fileDescriptor", "descriptor1")
+    assert result == ["descriptor1"]
+    mock_set_output_variable.assert_called_once_with("fileDescriptor", ["descriptor1"])
 
 
 @patch("requests.post")

--- a/camunda-utils/setup.py
+++ b/camunda-utils/setup.py
@@ -6,7 +6,7 @@ os.chdir(setup_dir)
 
 setup(
     name="camunda-utils",
-    version="0.5.0",
+    version="1.0.0",
     description="Offer keywords to interact with Camunda from the RPA worker",
     author="Camunda Services GmbH",
     author_email="info@camunda.com",


### PR DESCRIPTION
This aligns the RPA behavior with Tasklists file upload behavior.

closes #16