### PR TITLE
chore: adjust build system to pyproject.toml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel
+          pip install build wheel
 
       - name: Determine library to build
         id: determine-library
@@ -44,8 +44,8 @@ jobs:
       - name: Build library
         run: |
           cd ${{ env.library }}
-          sed -i 's/9.9.9-SNAPSHOT/${{ env.version }}/' setup.py
-          python setup.py sdist bdist_wheel
+          sed -i 's/9.9.9.dev0/${{ env.version }}/' pyproject.toml
+          python -m build
 
       - name: Upload Release Assets
         uses: actions/upload-release-asset@v1
@@ -53,8 +53,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ env.library }}/dist/${{ env.library }}-${{ env.version }}.tar.gz
-          asset_name: ${{ env.library }}-${{ env.version }}.tar.gz
+          asset_path: ${{ env.library }}/dist/${{ env.library_underscore }}-${{ env.version }}.tar.gz
+          asset_name: ${{ env.library_underscore }}-${{ env.version }}.tar.gz
           asset_content_type: application/gzip
 
       - name: Upload Wheel Asset

--- a/camunda-rpa/LICENSE
+++ b/camunda-rpa/LICENSE
@@ -1,0 +1,65 @@
+Camunda License 1.0
+
+The Camunda License (the “License”) sets forth the terms and conditions
+under which Camunda Services GmbH ("the Licensor") grants You a license
+solely to the source code in this repository ("the Software").
+
+Acceptance
+By Using the Software, You agree to all the terms and conditions below.
+If Your Use of the Software does not comply with the terms and conditions
+described in this License, You must purchase a commercial license from the
+Licensor, its affiliated entities, or authorized resellers, or You must
+refrain from Using the Software. If You receive the Software in original or
+modified form from a third party, the terms and conditions outlined in this
+License apply to Your Use of that Software. You should have received a copy
+of this License in this case.
+ 
+Copyright License
+Subject to the terms and conditions of this License, the Licensor hereby grants
+You the non-exclusive, royalty-free, worldwide, non-sublicensable, non-transferable
+right to Use the Software in any way or manner that would otherwise infringe the
+Licensor’s copyright as long and insofar as You Use the Software only and limited
+to the Use in or for the purpose of Using the Software in Non-Production Environment.  
+Each time you distribute or make otherwise publicly available the Software or
+Derivative Works thereof, the recipient automatically receives a license from
+the original Licensor to the respective Software or Derivative Works thereof
+under the terms of this License.
+
+Conditions and Restrictions
+All Use of the Software is explicitly made subject to the following conditions:
+  * You may not move, change, disable, or circumvent the license key functionality
+    in the Software, and You may not remove or obscure any functionality in the
+    Software that is protected by the license key.
+  * If You distribute or make available the Software or any modification or Derivative
+    Works thereof (including compiled versions), You must conspicuously display and
+    attach this License on each original or modified copy of the Software and enable
+    the recipient to obtain the source code if You have distributed a compiled version
+
+
+Patent License
+Patent and trademark rights are not licensed under this Public License.
+
+
+No Liability
+EXCEPT FOR DAMAGES CAUSED BY INTENT OR FRAUDULENTLY CONCEALED DEFECTS, AND EXCEPT FOR
+DAMAGES RESULTING FROM BREACH OF ANY WARRANTY OR GUARANTEE EXPRESSLY GIVEN BY LICENSOR
+IN THIS LICENCE, IN NO EVENT WILL LICENSOR BE LIABLE TO YOU ON ANY LEGAL THEORY FOR ANY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK. ANY MANDATORY STATUTORY
+LIABILITY UNDER APPLICABLE LAW REMAINS UNAFFECTED.
+ 
+No Warranty
+EXCEPT AS EXPRESSLY STATED IN THIS LICENSE OR REQUIRED BY APPLICABLE LAW, THE WORKS ARE
+PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND INCLUDING WITHOUT LIMITATION,
+ANY WARRANTIES REGARDING THE CONTENTS, ACCURACY, OR FITNESS FOR A PARTICULAR PURPOSE.
+
+
+Definitions
+You refer to the individual or entity agreeing to these terms.
+Use means any action concerning the Software that, without permission, would make Youliable
+for infringement under applicable copyright law. Use within the meaning of this License
+includes, but is not limited to, copying, distribution (with or without modification),
+making available to the public, and modifying the Software.
+
+Non-Production Environment means a setting in which the Software is used for development, staging,
+testing, quality assurance, demonstration, or evaluation purposes, and not for any live or
+production systems. 

--- a/camunda-rpa/pyproject.toml
+++ b/camunda-rpa/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "camunda-rpa"
+version = "9.9.9.dev0"
+description = "Exposes RPA libraries under the Camunda namespace"
+authors = [
+    { name = "Camunda Services GmbH", email = "info@camunda.com" }
+]
+license-files = ["LICENSE"] 
+requires-python = ">=3.7"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]
+
+dependencies = [
+    "rpaframework>=30",
+    "rpaframework-pdf>=8",
+    "rpaframework-windows>=9"
+]
+
+[project.urls]
+Homepage = "https://github.com/camunda/rpa-python-libraries"

--- a/camunda-rpa/setup.py
+++ b/camunda-rpa/setup.py
@@ -5,11 +5,6 @@ setup_dir = os.path.dirname(os.path.abspath(__file__))
 os.chdir(setup_dir)
 
 setup(
-    name="camunda-rpa",
-    version="9.9.9-SNAPSHOT",
-    description="Exposes RPA libraries under the Camunda namespace",
-    author="Camunda Services GmbH",
-    author_email="info@camunda.com",
     packages=[
         "Camunda.Archive",
         "Camunda.Browser.Selenium",
@@ -33,10 +28,5 @@ setup(
         "Camunda.Tasks",
         "Camunda.Windows",
         "Camunda.Word.Application",
-    ],
-    install_requires=[
-        "rpaframework >= 30",
-        "rpaframework-pdf >= 8",
-        "rpaframework-windows >= 9",
     ],
 )

--- a/camunda-utils/LICENSE
+++ b/camunda-utils/LICENSE
@@ -1,0 +1,65 @@
+Camunda License 1.0
+
+The Camunda License (the “License”) sets forth the terms and conditions
+under which Camunda Services GmbH ("the Licensor") grants You a license
+solely to the source code in this repository ("the Software").
+
+Acceptance
+By Using the Software, You agree to all the terms and conditions below.
+If Your Use of the Software does not comply with the terms and conditions
+described in this License, You must purchase a commercial license from the
+Licensor, its affiliated entities, or authorized resellers, or You must
+refrain from Using the Software. If You receive the Software in original or
+modified form from a third party, the terms and conditions outlined in this
+License apply to Your Use of that Software. You should have received a copy
+of this License in this case.
+ 
+Copyright License
+Subject to the terms and conditions of this License, the Licensor hereby grants
+You the non-exclusive, royalty-free, worldwide, non-sublicensable, non-transferable
+right to Use the Software in any way or manner that would otherwise infringe the
+Licensor’s copyright as long and insofar as You Use the Software only and limited
+to the Use in or for the purpose of Using the Software in Non-Production Environment.  
+Each time you distribute or make otherwise publicly available the Software or
+Derivative Works thereof, the recipient automatically receives a license from
+the original Licensor to the respective Software or Derivative Works thereof
+under the terms of this License.
+
+Conditions and Restrictions
+All Use of the Software is explicitly made subject to the following conditions:
+  * You may not move, change, disable, or circumvent the license key functionality
+    in the Software, and You may not remove or obscure any functionality in the
+    Software that is protected by the license key.
+  * If You distribute or make available the Software or any modification or Derivative
+    Works thereof (including compiled versions), You must conspicuously display and
+    attach this License on each original or modified copy of the Software and enable
+    the recipient to obtain the source code if You have distributed a compiled version
+
+
+Patent License
+Patent and trademark rights are not licensed under this Public License.
+
+
+No Liability
+EXCEPT FOR DAMAGES CAUSED BY INTENT OR FRAUDULENTLY CONCEALED DEFECTS, AND EXCEPT FOR
+DAMAGES RESULTING FROM BREACH OF ANY WARRANTY OR GUARANTEE EXPRESSLY GIVEN BY LICENSOR
+IN THIS LICENCE, IN NO EVENT WILL LICENSOR BE LIABLE TO YOU ON ANY LEGAL THEORY FOR ANY
+DAMAGES ARISING OUT OF THIS LICENSE OR THE USE OF THE WORK. ANY MANDATORY STATUTORY
+LIABILITY UNDER APPLICABLE LAW REMAINS UNAFFECTED.
+ 
+No Warranty
+EXCEPT AS EXPRESSLY STATED IN THIS LICENSE OR REQUIRED BY APPLICABLE LAW, THE WORKS ARE
+PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND INCLUDING WITHOUT LIMITATION,
+ANY WARRANTIES REGARDING THE CONTENTS, ACCURACY, OR FITNESS FOR A PARTICULAR PURPOSE.
+
+
+Definitions
+You refer to the individual or entity agreeing to these terms.
+Use means any action concerning the Software that, without permission, would make Youliable
+for infringement under applicable copyright law. Use within the meaning of this License
+includes, but is not limited to, copying, distribution (with or without modification),
+making available to the public, and modifying the Software.
+
+Non-Production Environment means a setting in which the Software is used for development, staging,
+testing, quality assurance, demonstration, or evaluation purposes, and not for any live or
+production systems. 

--- a/camunda-utils/pyproject.toml
+++ b/camunda-utils/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "camunda-utils"
+version = "9.9.9.dev0"
+description = "Offer keywords to interact with Camunda from the RPA worker"
+authors = [
+    { name = "Camunda Services GmbH", email = "info@camunda.com" }
+]
+license-files = ["LICENSE"] 
+requires-python = ">=3.7"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+    "robotframework"
+]
+
+[project.urls]
+Homepage = "https://github.com/camunda/rpa-python-libraries"

--- a/camunda-utils/setup.py
+++ b/camunda-utils/setup.py
@@ -5,11 +5,5 @@ setup_dir = os.path.dirname(os.path.abspath(__file__))
 os.chdir(setup_dir)
 
 setup(
-    name="camunda-utils",
-    version="9.9.9-SNAPSHOT",
-    description="Offer keywords to interact with Camunda from the RPA worker",
-    author="Camunda Services GmbH",
-    author_email="info@camunda.com",
     packages=["Camunda"],
-    install_requires=["robotframework"],
 )


### PR DESCRIPTION
This PR moves our build environment to `pyproject.toml`. This is in preparation of releasing our libraries on Pypi.

related to https://github.com/camunda/rpa-python-libraries/issues/17